### PR TITLE
Fix 24h window subscription problem

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -3,7 +3,6 @@ How to Run
 ==========
 
 In order to run Maid-chan properly, you need to be able to use `Facebook Messenger Bot`_.
-There is a simple echo bot which is provided by `davidchua/pymessenger`_.
 
 Maid-chan Installation
 ----------------------
@@ -78,5 +77,4 @@ Maid-chan has 3 executables (recommended to use `screen`):
 - **maidchan_scheduler**: Scheduler which is used to handle daily and repetitive tasks, such as :ref:`Daily Offerings`, :ref:`Daily Japanese Lesson`, :ref:`RSS Feed Notifier`, and :ref:`Tokyo Train Status feat Yahoo Japan`.
 
 .. _Facebook Messenger Bot: https://developers.facebook.com/docs/messenger-platform/guides/quick-start
-.. _davidchua/pymessenger: https://github.com/davidchua/pymessenger/blob/master/examples/echo_bot.py
 .. _Chatterbot Documentation: http://chatterbot.readthedocs.io/en/stable/storage/index.html

--- a/maidchan/cmds/primitive_worker.py
+++ b/maidchan/cmds/primitive_worker.py
@@ -7,11 +7,8 @@ import time
 
 from maidchan.base import connect_redis, RedisDriver
 from maidchan.config import ACCESS_TOKEN
-from maidchan.helper import send_image
+from maidchan.helper import send_text_message, send_image
 from maidchan.primitive import process_image
-from pymessenger.bot import Bot
-
-bot = Bot(ACCESS_TOKEN)
 
 
 class ThreadHandler(threading.Thread):
@@ -28,12 +25,15 @@ class ThreadHandler(threading.Thread):
                     ACCESS_TOKEN,
                     self.data.get('recipient_id', ""),
                     image_path,
-                    image_type
+                    image_type,
+                    passive=False
                 )
             else:
-                bot.send_text_message(
+                send_text_message(
+                    ACCESS_TOKEN,
                     self.data.get('recipient_id', ""),
-                    "なにそれ？意味わかない!"
+                    "なにそれ？意味わかない!",
+                    passive=False
                 )
         finally:
             # cleanup temporary directory

--- a/maidchan/cmds/scheduler_worker.py
+++ b/maidchan/cmds/scheduler_worker.py
@@ -9,7 +9,7 @@ from random import randint
 from maidchan.base import connect_redis, RedisDriver
 from maidchan.command import DEFAULT_NICKNAME
 from maidchan.config import ACCESS_TOKEN
-from maidchan.helper import send_image
+from maidchan.helper import send_text_message, send_image
 from maidchan.japanese import get_random_kanji, get_random_vocabulary,\
     get_japanese_message
 from maidchan.offerings import get_morning_offerings_text,\
@@ -17,12 +17,8 @@ from maidchan.offerings import get_morning_offerings_text,\
     SPECIAL
 from maidchan.rss import get_feed
 from maidchan.train_status import get_train_status
-from pymessenger.bot import Bot
 
 from maidchan.helper import time_to_next_utc_mt
-
-
-bot = Bot(ACCESS_TOKEN)
 
 
 def send_offerings(recipient_id, text_message, image_path):
@@ -33,9 +29,11 @@ def send_offerings(recipient_id, text_message, image_path):
     else:
         image_type = None
     # Send good morning / good night message
-    bot.send_text_message(
+    send_text_message(
+        ACCESS_TOKEN,
         recipient_id,
-        text_message
+        text_message,
+        passive=True
     )
     # Send image offerings if file exists and recognizable
     if image_path and image_type:
@@ -43,7 +41,8 @@ def send_offerings(recipient_id, text_message, image_path):
             ACCESS_TOKEN,
             recipient_id,
             image_path,
-            image_type
+            image_type,
+            passive=True
         )
 
 
@@ -92,7 +91,12 @@ def process_user_schedules(redis_client, recipient_id, metadata, current_mt):
                     metadata["kanji_{}".format(level)],
                     metadata["vocabulary"]
                 )
-                bot.send_text_message(recipient_id, message)
+                send_text_message(
+                    ACCESS_TOKEN,
+                    recipient_id,
+                    message,
+                    passive=True
+                )
             except Exception:
                 pass
             while user["schedules"]["japanese_lesson_mt"] < int(time.time()):
@@ -126,7 +130,12 @@ def process_user_rss(redis_client, recipient_id):
                     url,
                     user.get("nickname", DEFAULT_NICKNAME)
                 )
-                bot.send_text_message(recipient_id, message)
+                send_text_message(
+                    ACCESS_TOKEN,
+                    recipient_id,
+                    message,
+                    passive=True
+                )
                 user["rss"][key]["title_list"].append(title)
                 redis_client.set_user(recipient_id, user)
 
@@ -184,7 +193,12 @@ def process_train_notification(redis_client, recipient_id,
             message += "\nReason: {}".format(
                 notification["reason"].encode("utf-8")
             )
-        bot.send_text_message(recipient_id, message)
+        send_text_message(
+            ACCESS_TOKEN,
+            recipient_id,
+            message,
+            passive=True
+        )
 
 
 def process_user(redis_client, recipient_id, metadata, current_mt,

--- a/maidchan/helper.py
+++ b/maidchan/helper.py
@@ -15,12 +15,13 @@ def send_text_message(access_token, recipient_id, text, passive=False):
     """
     Note: MESSAGE_TAG is introduced to circumvent 24+1h window limit
     """
+    escaped_text = text.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n')
     args = [
         'curl',
         '-F',
         'recipient={"id":"%s"}' % recipient_id,
         '-F',
-        'message={"text": "%s"}' % text
+        'message={"text": "%s"}' % escaped_text
     ]
     if passive:
         args.append('-F')
@@ -46,8 +47,7 @@ def send_text_message(access_token, recipient_id, text, passive=False):
 def send_image(access_token, recipient_id, image_path,
                image_type, passive=False):
     """
-    Since pymessenger has a bug in sending image,
-    we will use this method for time being
+    Note: MESSAGE_TAG is introduced to circumvent 24+1h window limit
     """
     args = [
         'curl',

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,14 +11,12 @@ langdetect==1.0.7
 nltk==3.2.2
 numpy==1.11.3
 oauthlib==2.0.1
-pymessenger==0.0.7.0
 pymongo==3.4.0
 python-twitter==3.2
 pytz==2017.2
 redis==2.10.5
 requests==2.12.4
 requests-oauthlib==0.7.0
-requests-toolbelt==0.7.0
 singledispatch==3.4.0.3
 six==1.10.0
 Sphinx==1.5.1


### PR DESCRIPTION
From https://developers.facebook.com/docs/messenger-platform/policy/policy-overview#standard_messaging:

> 24-Hour Messaging Window
Businesses and developers using the Send API have up to 24 hours to respond to a message sent by a person in Messenger when using standard messaging. A bot may also send one additional message after the 24-hour time limit has expired. The 24-hour limit is refreshed each time a person responds to a business through one of the eligible actions listed in Messenger Conversation Entry Points. This is commonly referred to as the '24 + 1 policy'. For information on how you may be able to send messages outside the 24-hour messaging window, see the Tags documentation, and Sponsored Messages.